### PR TITLE
Create self-assign command

### DIFF
--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -1,0 +1,23 @@
+name: Self-assign
+on:
+  issue_comment:
+    types: created
+jobs:
+  self-assign:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event.comment.body == '#take' ||
+       github.event.comment.body == '#self-assign')
+    steps:
+      - run: |
+          echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+          curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+  self-unassign:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event.comment.body == '#untake' ||
+       github.event.comment.body == '#self-unassign')
+    steps:
+      - run: |
+          echo "Unassigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+          curl -X DELETE -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees


### PR DESCRIPTION
People can self-assign an issue to themselves by writing a comment on the Issue page just containing the keyword (attention: no blanks, no newlines):
`
#self-assign
`

Analogously, they can self-unassign an issue by writing:
`
#self-unassign
`

I think we should recommend to take issues one by one (not many at the same time), so that we do not block the progress other users can take. A participant self-assigns a single issue and works on it until finished. Once finished, they can self-assign a new issue and work on it until finished. And so on...

@davanstrien what do you think?

Close #9 