### PR TITLE
Add size field to the datasets form 

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_dataset.yml
+++ b/.github/ISSUE_TEMPLATE/add_dataset.yml
@@ -73,6 +73,18 @@ body:
         - Other
     validations:
       required: true
+ - type: dropdown
+    id: size
+    attributes:
+      label: size of dataset
+      description: What is the size of this dataset?
+      options:
+        - <500MB
+        - 500MB-2GB
+        - 2GB-10GB 
+        - >10GB
+    validations:
+      required: false
   - type: checkboxes
     id: open
     attributes:


### PR DESCRIPTION
closes #73 

Adds a dataset size field to make it easier for potential participants to decide if a dataset might be practical for them to work on. This is left optional since it won't always be possible to calculate this. I could also make it mandatory and make an 'unknown' option. 